### PR TITLE
Fix error in example

### DIFF
--- a/src/examples/basics.md
+++ b/src/examples/basics.md
@@ -108,7 +108,6 @@ fun f (x, y) =
     case x of 
       0 => 0
     | y => y
-    | _ => x
 val a = f (y, x)
 val b = f (x, y)
 ```


### PR DESCRIPTION
Not sure if this is the best fix, but should fix somehow.

Some other options:
- Say that the answer is NWT/match redundant error, explaining why
- Pattern match on a tuple (say, `(x,x)` or `(x,y)`?) with one of the cases being `(y,7)` or something, so you can still end with a `_ => x`