### PR TITLE
Minor edit: fix unmatched code block delimiter

### DIFF
--- a/src/concepts/mods.md
+++ b/src/concepts/mods.md
@@ -213,9 +213,7 @@ struct
     fun get_y (x, y) = y
     fun get_dist (x, y) = Math.sqrt (Math.pow (x, 2.0) + Math.pow (y, 2.0))
 end
-```
 
-```sml
 structure PolarGeo : GEOMETRY =
 struct
     (* pair of (d, theta), where d is distance from origin and theta is angle from 0 degrees *)

--- a/src/concepts/mods.md
+++ b/src/concepts/mods.md
@@ -213,6 +213,7 @@ struct
     fun get_y (x, y) = y
     fun get_dist (x, y) = Math.sqrt (Math.pow (x, 2.0) + Math.pow (y, 2.0))
 end
+```
 
 ```sml
 structure PolarGeo : GEOMETRY =


### PR DESCRIPTION
In concepts/mods.md, there is an ` ```sml` delimiter that's unmatched. This PR is a minor edit to fix it.