### PR TITLE
Fixed typos in Common HOFs, Tail Recursion, CPS

### DIFF
--- a/src/concepts/common.md
+++ b/src/concepts/common.md
@@ -1,5 +1,5 @@
 # Common HOFs and Partial Evaluation
-_By Brandon Wu, June 2020_
+_By Brandon Wu, June 2020. Revised March 2022_
 
 In this section, we will explore a number of common higher-order functions that
 we will make use of. These higher-order functions embody _design patterns_ that
@@ -212,10 +212,10 @@ by the given higher-order function.
 A key strength of higher-order functions lies in _partial evaluation_, where we
 can use higher-order functions to further derive other functions (and possibly
 higher-order functions, themselves). It is fine for, in the case of finding the
-sum of a single list `L`, to simply evaluate `map (op+) L`, but in the general
-case it is a strength that we can bind the function `map (op+)` to the name
+sum of a single list `L`, to simply evaluate `foldr (op+) 0 L`, but in the general
+case it is a strength that we can bind the function `foldr (op+) 0` to the name
 `sum`. This comes in handy especially if we want to sum over _many_ lists, so
-that we don't continuously have to compute the result of `map (op+)` (though it
+that we don't continuously have to compute the result of `foldr (op+) 0` (though it
 has negligible computational cost, admittedly).
 
 Seen in this way, it is as if higher-order functions are at the root of a large

--- a/src/concepts/cps.md
+++ b/src/concepts/cps.md
@@ -10,7 +10,7 @@ figure figcaption {
 </style>
 
 # Continuation Passing Style
-_By Brandon Wu, June 2020_
+_By Brandon Wu, June 2020. Revised March 2022_
 
 We have seen how we can write functions that are _tail recursive_, in that they
 only make recursive calls as _tail calls_, where the recursive calls is the last
@@ -351,7 +351,7 @@ we should visit next. Clearly, we visit `T2` first, so the red brick
 corresponding to `T2` is on top.
 
 Our next move is to pop it off first, which will cause our expression to now
-have three bricks - two corresponding to the children of `T3`, and one
+have three bricks - two corresponding to the children of `T2`, and one
 corresponding to `T4`. We can visualize the next phase as the following:
 
 <figure class="aligncenter">
@@ -360,7 +360,7 @@ corresponding to `T4`. We can visualize the next phase as the following:
     <figcaption class="center"><b>Fig 7.</b> Phase 2 of evaluation of the tree T. Note that two extra "bricks" have been added due to evaluation of treeSumCPS T2. </figcaption>
 </figure>
 
-where the brick labelled `treeSumCPS E` corrresponds to the empty child of
+where the brick labelled `treeSumCPS E` corresponds to the empty child of
 `T2`. Note that we have retained the blue flag at `T4` and left its brick alone,
 since for all intents and purposes we have not yet "touched" it - we have not
 evaluated our stack to that point. Note that due to corresponding to the `Empty`
@@ -485,8 +485,8 @@ fun knapsackCPS
   : 'a =
   case L of
     [] => if minVal <= 0 andalso maxWeight >= 0 then sc [] 
-                                                else k ()
-  | (v, w)::xs => if maxWeight < 0 then k ()
+                                                else fc ()
+  | (v, w)::xs => if maxWeight < 0 then fc ()
                                    else
     knapsackCPS ((v, w)::xs) (minVal - v) (maxWeight - w) 
     (fn L' => sc ((v, w)::L')) (fn () => knapsackCPS xs minVal maxWeight sc fc)
@@ -514,7 +514,7 @@ realized in the algorithm in the next part.
 ```sml
 case L of
     [] => if minVal <= 0 andalso maxWeight >= 0 then sc [] 
-                                                else k ()
+                                                else fc ()
 ```
 
 For the base case, however, we know that if we are given no items whatsoever,
@@ -550,7 +550,7 @@ imagine our choice to be whether to put the first element of the list into the
 knapsack, or to not. 
 
 ```sml
-| (v, w)::xs => if maxWeight < 0 then k ()
+| (v, w)::xs => if maxWeight < 0 then fc ()
                                    else
     knapsackCPS ((v, w)::xs) (minVal - v) (maxWeight - w) 
     (fn L' => sc ((v, w)::L')) (fn () => knapsackCPS xs minVal maxWeight sc fc)

--- a/src/concepts/tail.md
+++ b/src/concepts/tail.md
@@ -1,5 +1,5 @@
 # Tail Recursion
-_By Eunice Chen and Brandon Wu, December 2020_
+_By Eunice Chen and Brandon Wu, December 2020. Revised March 2022_
 
 In programs, functions often make calls to either themselves (recursive calls) or other functions. There are two types of function calls: non-tail calls, and **tail calls**. A function call is called a **tail call** if the caller does not modify or examine the result of the function call.
 
@@ -81,7 +81,7 @@ fun fib 0 = (1, 0)
 This is closer, but we still are doing computation after the recursive call: we add the results of the recursive call to each other, then return. Let's try to use the accumulator idea we had earlier in the `sum` function, but this time, since we calculate the `n`th and (`n-1`)th Fibonacci number, we will pass in two accumulators. Accumulator `a` will hold the `n`th Fibonacci number, and accumulator `b` will hold the (`n-1`)th Fibonacci number.
 ```sml
 fun fib' (0, a, b) = a
-  | fib' (n, a, b) = fib' (n-1, a + b, b)
+  | fib' (n, a, b) = fib' (n-1, a + b, a)
 ```
 And if we call `fib' (n, 1, 0)`, observe that we will indeed get the correct result.
 


### PR DESCRIPTION
Closes #50, #49, and #40 (decided not to do anything about the labeling of the empty trees since that would require changing the images).