### PR TITLE
Fixed misrendered LaTeX/other typos

### DIFF
--- a/docs/concepts/asymptotic/workspan.mdx
+++ b/docs/concepts/asymptotic/workspan.mdx
@@ -2,7 +2,7 @@
 
 import { Figure } from "@site/src/components/Figure";
 
-_By Aditi Gupta and Brandon Wu, May 2020_. _Revised September 2020_
+_By Aditi Gupta and Brandon Wu, May 2020_. _Revised December 2022_
 
 We will now turn towards a more robust notion of _work_ and _span_ that let us analyze our conception of asymptotic runtime more effectively. It is still dependent on asymptotic analysis, but merely involves being more involved with how we go about generating the asymptotic bound for a function from the code itself. Additionally, we will not only analyze the approximate _number of steps_ of the program (which corresponds to the _runtime_ of the program, given sequential execution), but also the approximate _longest chain of dependencies_ that exists in the program, assuming that computations can be run in parallel. We will elaborate more on this idea in this chapter.
 
@@ -71,15 +71,15 @@ W_{length}(n) &= c_0 + W_{length}(n-1)
 \end{aligned}
 $$
 
-This recurrence is made of two parts - the recursive case and the base case. The first equation for $W*{length}(n)$ simply denotes what the work for an input size of $n$ should be - defined recursively. The second equation for $W*{length}(0)$ defines what the work for an input size of $0$ should be. This directly corresponds to our code, which has two clauses for a list of length $0$ (that being `[]`), and for the general case. This is an important observation to make, that the recurrence follows directly from the code.
+This recurrence is made of two parts - the recursive case and the base case. The first equation for $W_{length}(n)$ simply denotes what the work for an input size of $n$ should be - defined recursively. The second equation for $W_{length}(0)$ defines what the work for an input size of $0$ should be. This directly corresponds to our code, which has two clauses for a list of length $0$ (that being `[]`), and for the general case. This is an important observation to make, that the recurrence follows directly from the code.
 
-The recursive case says that, for an input of size $n$, the work done is $c*0 + W*{length}(n-1)$. Here, $c*0$ denotes \_some\* constant. This is supposed to correspond to the recursive case of the function, and if we look at it, we have a recursive call `length xs`, as well as some other work of adding one. Adding one, being an arithmetic operation, is a constant-time process, meaning that it takes a non-zero constant amount of time. This is what $c_0$ is supposed to represent - the constant amount of non-recursive work that must be done, after the recursive call has finished. It is not important what $c_0$ is, just that it is some unspecified amount of work that is not a function of $n$.
+The recursive case says that, for an input of size $n$, the work done is $c_0 + W_{length}(n-1)$. Here, $c_0$ denotes some constant. This is supposed to correspond to the recursive case of the function, and if we look at it, we have a recursive call `length xs`, as well as some other work of adding one. Adding one, being an arithmetic operation, is a constant-time process, meaning that it takes a non-zero constant amount of time. This is what $c_0$ is supposed to represent - the constant amount of non-recursive work that must be done, after the recursive call has finished. It is not important what $c_0$ is, just that it is some unspecified amount of work that is not a function of $n$.
 
-Conversely, $W\_{length}(n-1)$ represents exactly the amount of work done by the recursive call, since it is literally defined to be the amount of work done by an input of size $n-1$, which is exactly what happens when we call `length xs`, where `xs` has length $n-1$.
+Conversely, $W_{length}(n-1)$ represents exactly the amount of work done by the recursive call, since it is literally defined to be the amount of work done by an input of size $n-1$, which is exactly what happens when we call `length xs`, where `xs` has length $n-1$.
 
 **NOTE:** Even if we did not have the addition operation, we would still have $c_0$. This is because merely entering the function and figuring out which case to execute takes some non-zero amount of work - it is impossible to run the recursive call perfectly with no other time expense. As such, we would see exactly the same recurrence even if the recursive case was `length (x::xs : int list) : int = length xs` (which would also be a very bad length function).
 
-For the base case, we have that $W\_{length}(0) = c_1$, since in the base case we just return 0. This has a constant amount of work associated with it, as argued previously, so we use the constant $c_1$ to denote that, since the amount of work is likely not the same constant as that in the recursive case, when adding 1.
+For the base case, we have that $W_{length}(0) = c_1$, since in the base case we just return `0`. This has a constant amount of work associated with it, as argued previously, so we use the constant $c_1$ to denote that, since the amount of work is likely not the same constant as that in the recursive case, when adding 1.
 
 So this is how we arrive at the work recurrence for `length`. We will now turn to the span recurrence, which we obtain as:
 
@@ -90,16 +90,16 @@ S_{length}(n) &= c_0 + S_{length}(n-1)
 \end{aligned}
 $$
 
-Note that the span recurrence is exactly the same as the work recurrence. This should make sense, because there is no opportunity for parallelism in the `length` function - we can only pop off elements one by one from the list. In the recursive case, we must wait for the result of the recursive call on `xs`, which means we unavoidably must expend the span of $S*{length}(n-1)$ - additionally, we have a data dependency. We cannot execute the addition in `1 + length xs` until we obtain the result for `length xs`, which means that we must sum the time it takes to compute `length xs` (that being $S*{length}(n-1)$) and the time it takes to carry out the addition operation (that being $c_1$).
+Note that the span recurrence is exactly the same as the work recurrence. This should make sense, because there is no opportunity for parallelism in the `length` function - we can only pop off elements one by one from the list. In the recursive case, we must wait for the result of the recursive call on `xs`, which means we unavoidably must expend the span of $S_{length}(n-1)$ - additionally, we have a data dependency. We cannot execute the addition in `1 + length xs` until we obtain the result for `length xs`, which means that we must sum the time it takes to compute `length xs` (that being $S_{length}(n-1)$) and the time it takes to carry out the addition operation (that being $c_1$).
 
 Now we will begin the task of actually solving the recurrence. They are the same recurrence, so without loss of generality we will solve just the work recurrence.
 
-We know that it has the form of $W*{length}(n) = c_0 + W*{length}(n-1)$, and eventually reaches a base case at $W\_{length}(0) = c_1$. We can "unroll" the recurrence a few times to see if we can see a pattern, and then arrive at our answer.
+We know that it has the form of $W_{length}(n) = c_0 + W_{length}(n-1)$, and eventually reaches a base case at $W_{length}(0) = c_1$. We can "unroll" the recurrence a few times to see if we can see a pattern, and then arrive at our answer.
 
-So we start out with $W*{length}(n) = c_0 + W*{length}(n-1)$, but if we invoke the definition of $W*{length}(n-1)$, we can produce $c_0 + c_0 + W*{length}(n-2)$, since $W*{length}(n-1) = c_0 + W*{length}(n-2)$. By doing the same for $W*{length}(n-2)$, we get $c_0 + c_0 + c_0 + W*{length}(n-3)$. It seems we've hit upon a pattern - each time we "unroll" the definition of $W\_{length}(n)$, for progressively lower $n$, we get another $c_0$ term back out. Then, we know that the recurrence should eventually solve to:
+So we start out with $W_{length}(n) = c_0 + W_{length}(n-1)$, but if we invoke the definition of $W_{length}(n-1)$, we can produce $c_0 + c_0 + W_{length}(n-2)$, since $W_{length}(n-1) = c_0 + W_{length}(n-2)$. By doing the same for $W_{length}(n-2)$, we get $c_0 + c_0 + c_0 + W_{length}(n-3)$. It seems we've hit upon a pattern - each time we "unroll" the definition of $W_{length}(n)$, for progressively lower $n$, we get another $c_0$ term back out. Then, we know that the recurrence should eventually solve to:
 
 $$
-W_{length}(n) = (\sum_{(i = 1)}^n c_0) + c_1
+W_{length}(n) = (\sum_{i = 1}^n c_0) + c_1
 $$
 
 We will usually omit the $c_1$, since it does not matter asymptotically. Then, clearly this is equivalent to $nc_0 + c_1$. We see that this closed-form solution is linear in $n$ - so then we have that the work and span of this function is in $O(n)$, which is consistent with what we would expect if we had "eyeballed" it.
@@ -162,9 +162,9 @@ W_{size}(n) &= c_0 + W_{size}(n_l) + W_{size}(n_r)
 \end{aligned}
 $$
 
-where we define the number of nodes in the tree $n = 1 + n*l + n_r$, and $n_l$ and $n_r$ denote the number of nodes in the left and right subtree, respectively. This follows similarly to our recurrence for `length` in the previous part, where `c_0` is just some constant amount of work that we necessarily have to do, and the two $W*{size}$ calls are from the two recursive calls we make to `L` and `R`.
+where we define the number of nodes in the tree $n = 1 + n_l + n_r$, and $n_l$ and $n_r$ denote the number of nodes in the left and right subtree, respectively. This follows similarly to our recurrence for `length` in the previous part, where `c_0` is just some constant amount of work that we necessarily have to do, and the two $W_{size}$ calls are from the two recursive calls we make to `L` and `R`.
 
-Now, we don't know precisely how big $n*l$ and $n_r$ are, with respect to $n$. This makes our analysis a little more tricky, but essentially all we need to do is think of the \_worst case\*, as we are interested in the worst-case asymptotic complexity of this function. For work, however, there is no worst-case - no matter how the tree is structured, we must visit every node once, doing a constant amount of work each time. So we should obtain, in the end, $W\_{size}(n) = nc_0 + c_1$, which we know is $O(n)$. So in this case, we didn't have to think about the structure of the tree. In the next section, it will matter.
+Now, we don't know precisely how big $n_l$ and $n_r$ are, with respect to $n$. This makes our analysis a little more tricky, but essentially all we need to do is think of the _worst case_, as we are interested in the worst-case asymptotic complexity of this function. For work, however, there is no worst-case - no matter how the tree is structured, we must visit every node once, doing a constant amount of work each time. So we should obtain, in the end, $W_{size}(n) = nc_0 + c_1$, which we know is $O(n)$. So in this case, we didn't have to think about the structure of the tree. In the next section, it will matter.
 
 ## Work/Span Analysis: Balanced vs Unbalanced Trees
 
@@ -177,13 +177,13 @@ So we will write the span recurrence as follows:
 $$
 \begin{aligned}
 S_{size}(0) &= c_1 \\
-S_{size}(n) &= c_0 + max(S_{size}(n_l), S_{size}(n_r))
+S_{size}(n) &= c_0 + \max(S_{size}(n_l), S_{size}(n_r))
 \end{aligned}
 $$
 
 Now note that we are taking the max over the two recursive calls. Now, we cannot handwave the structure of the tree like we did in the previous part - if one path is significantly longer than the other, then it will stall the computation for longer. We still must visit every node, but some of them can occur in parallel.
 
-We will consider the first case - if we have an unbalanced tree. Suppose that the tree is heavily unbalanced - akin to a (diagonal) linked list. Without loss of generality, let it be "pointing" to the left. Then, $n*l = n - 1$, and $n_r = 0$. Then, the max over both recursive calls should clearly be that of $S*{size}(n-1)$, since it has to compute the size of a larger tree.
+We will consider the first case - if we have an unbalanced tree. Suppose that the tree is heavily unbalanced - akin to a (diagonal) linked list. Without loss of generality, let it be "pointing" to the left. Then, $n_l = n - 1$, and $n_r = 0$. Then, the max over both recursive calls should clearly be that of $S_{size}(n-1)$, since it has to compute the size of a larger tree.
 
 So we can update our recurrence and obtain:
 
@@ -209,9 +209,9 @@ $$
 
 This is slightly different than our `length` recurrence. We will try unrolling to make sense of this recurrence.
 
-We have that $S*{size}(n) = c_0 + S*{size}(\frac{n}{2})$. Plugging in the recursive definition of $S*{size}(\frac{n}{2})$, we get that this expands to $c_0 + c_0 + S*{size}(\frac{n}{4})$, which by the same trick expands to $c*0+ c_0 + c_0 + S*{size}(\frac{n}{8})$, and so on and so forth. We note that we are dividing the number of nodes by 2 each time - and we know that we can divide $n$ by two roughly $\log*2(n)$ times. So in total, we can solve the summation of $S*{size}(n)$ as $S*{size} = (\sum*{i=1}^{\log_2(n)} c_0) + c_1$.
+We have that $S_{size}(n) = c_0 + S_{size}(\frac{n}{2})$. Plugging in the recursive definition of $S_{size}(\frac{n}{2})$, we get that this expands to $c_0 + c_0 + S_{size}(\frac{n}{4})$, which by the same trick expands to $c_0+ c_0 + c_0 + S_{size}(\frac{n}{8})$, and so on and so forth. We note that we are dividing the number of nodes by 2 each time - and we know that we can divide $n$ by two roughly $\log_2(n)$ times. So in total, we can solve the summation of $S_{size}(n)$ as $S_{size}(n) = (\sum_{i=1}^{\log_2(n)} c_0) + c_1$.
 
-So then this simplifies to $S\_{size}(n) = \log_2(n)c_0 + c_1$. This is a logarithmic function of $n$, so we get that the span of `size` is in $O(\log n)$. Thus, we obtain a different span for balanced trees versus unbalanced trees - balanced trees are more efficient and parallelism-friendly.
+So then this simplifies to $S_{size}(n) = \log_2(n)c_0 + c_1$. This is a logarithmic function of $n$, so we get that the span of `size` is in $O(\log n)$. Thus, we obtain a different span for balanced trees versus unbalanced trees - balanced trees are more efficient and parallelism-friendly.
 
 ## Work/Span Analysis: Size-dependent Operations
 
@@ -232,7 +232,7 @@ import traversals from "@site/static/traversals.png";
   binary tree, with visited nodes labeled in ascending order
 </Figure>
 
-> Tree traversals can also come in handy when generating different notations for mathematical expressions when represented in the form of an _binary expression tree_, which has nodes that consist of either a _numeric constant_, which has no children, a _unary operation_ with a single child, or a _binary operation_ with two children. For instance, a binary expression tree for the mathematical expression $(4-1) \* 2$ is shown below.
+> Tree traversals can also come in handy when generating different notations for mathematical expressions when represented in the form of an _binary expression tree_, which has nodes that consist of either a _numeric constant_, which has no children, a _unary operation_ with a single child, or a _binary operation_ with two children. For instance, a binary expression tree for the mathematical expression $(4-1) * 2$ is shown below.
 
 import optree from "@site/static/optree.png";
 
@@ -240,9 +240,9 @@ import optree from "@site/static/optree.png";
   A binary expression tree for the expression (4 - 1) * 2
 </Figure>
 
-> With inorder traversal of this expression tree, we can generate the constants and symbols in exactly the same order as $(4-1) \* 2$, which is how we would normally interpret it. Preorder and postorder traversal, however, result in an interesting interpretation - what is known as _prefix_ (or _Polish_) and _postfix_ (or _Reverse Polish_) notation.
+> With inorder traversal of this expression tree, we can generate the constants and symbols in exactly the same order as $(4-1) * 2$, which is how we would normally interpret it. Preorder and postorder traversal, however, result in an interesting interpretation - what is known as _prefix_ (or _Polish_) and _postfix_ (or _Reverse Polish_) notation.
 >
-> In prefix notation, by using preorder traversal, we obtain the expression $_ - 4 1 2$, which is how we would interpret the same expression if all of our operators appeared before their operands. Similarly, with postorder traversal, we obtain the expression $4 1 - 2 _$ in postfix notation. Prefix and postfix notation have significance in their lack of ambiguity - while infix notation is easy for humans to read, it requires parentheses sometimes to denote how operator precedence takes place. Prefix and postfix notation have no such flaw - they are unambiguous in how operations take place. In programming language interpreters, such notations are sometimes used to represent mathematical expressions.
+> In prefix notation, by using preorder traversal, we obtain the expression `* - 4 1 2`, which is how we would interpret the same expression if all of our operators appeared before their operands. Similarly, with postorder traversal, we obtain the expression `4 1 - 2 *` in postfix notation. Prefix and postfix notation have significance in their lack of ambiguity - while infix notation is easy for humans to read, it requires parentheses sometimes to denote how operator precedence takes place. Prefix and postfix notation have no such flaw - they are unambiguous in how operations take place. In programming language interpreters, such notations are sometimes used to represent mathematical expressions.
 
 Such a digression serves as motivation for the next function that we will analyze - which is writing the preorder traversal of a tree in SML. The code looks like this:
 
@@ -255,7 +255,7 @@ We can readily see that this follows the root-left-right order that we specified
 
 We will analyze only the balanced case for this function. We invite the reader to think about the unbalanced case on their own.
 
-For the recursive case, we know that $W*{preord}(n)$ will take the form of $c_0 + W*@(n*l) + W*{preord}(n*l) + W*{preord}(n_r)$. By our balanced assumption, we know $n_l = n_r = \frac{n}{2}$, so we can write our work recurrence as:
+For the recursive case, we know that $W_{preord}(n)$ will take the form of $c_0 + W_@(n_l) + W_{preord}(n_l) + W_{preord}(n_r)$. By our balanced assumption, we know $n_l = n_r = \frac{n}{2}$, so we can write our work recurrence as:
 
 $$
 \begin{aligned}
@@ -264,7 +264,7 @@ W_{preord}(n) &= c_0 + \frac{n}{2}c_1 + 2W_{preord}(\frac{n}{2})
 \end{aligned}
 $$
 
-Note that the term $W*@(n_l)$ is a recurrence in terms of $n$, the size of the left list given as input to `@`. Since we know that the work complexity of `@` is $O(n)$, we can replace $W*@(\frac{n}{2})$ with $\frac{n}{2}c_1$, which is simply some constant $c_1$, scaled by a linear factor of the input $\frac{n}{2}$. This is how we will generally deal with analyzing the complexity of functions that make use of helper functions.
+Note that the term $W_@(n_l)$ is a recurrence in terms of $n$, the size of the left list given as input to `@`. Since we know that the work complexity of `@` is $O(n)$, we can replace $W_@(\frac{n}{2})$ with $\frac{n}{2}c_1$, which is simply some constant $c_1$, scaled by a linear factor of the input $\frac{n}{2}$. This is how we will generally deal with analyzing the complexity of functions that make use of helper functions.
 
 We will make use of a new method to solve this recurrence - the Tree Method.
 
@@ -282,11 +282,11 @@ We will now explore exactly how we arrived at this conclusion.
 
 First, note that this tree exists as a result of the recurrence. We used the code to specify the recurrence, and then the recurrence itself described this tree. It has a branching factor of 2 (that is, two children of each node that are non-leaves) since the recursive case of the recurrence has two recursive calls, and at each level the size of the input changes. Since the recursive calls are called on inputs of size $\frac{n}{2}$, each level results in a division by two of the input size.
 
-Additionally, we know that the amount of work at each node (of input size $n$) is necessarily $c_1 \frac{n}{2}$. There is technically also a $c_0$ term, but we will omit it since it is asymptotically dominated by $c_1 \frac{n}{2}$. The precise non-recursive work done by each "node" is specified slightly down and to the left of each node. Individually, they don't look very nice to sum over - at level $i$, it appears the work at each node is $c_1 \frac{n}{2^{i+1}}$. However, level $i$ also has $2^i$ nodes, by the branching nature of the recurrence tree. As such, the total amount of work done at level $i$ is just $c_1 \frac{n}{2^{i+1}} \* 2^i = c_1 \frac{n}{2}$, which is not a function of the level $i$.
+Additionally, we know that the amount of work at each node (of input size $n$) is necessarily $c_1 \frac{n}{2}$. There is technically also a $c_0$ term, but we will omit it since it is asymptotically dominated by $c_1 \frac{n}{2}$. The precise non-recursive work done by each "node" is specified slightly down and to the left of each node. Individually, they don't look very nice to sum over - at level $i$, it appears the work at each node is $c_1 \frac{n}{2^{i+1}}$. However, level $i$ also has $2^i$ nodes, by the branching nature of the recurrence tree. As such, the total amount of work done at level $i$ is just $c_1 \frac{n}{2^{i+1}} * 2^i = c_1 \frac{n}{2}$, which is not a function of the level $i$.
 
-As such, each level has the same amount of work - which is very convenient, as we can now just take that quantity and multiply it by the number of levels. So in total, when we solve out the recurrence, we should obtain that $W(n) = (\sum\_{i=1}^{\log_2(n)} c_1\frac{n}{2}) + c_2n$, since the $c_2n$ term is separately obtained from the base level, due to the $n$ leaves that each have $c_2$ work.
+As such, each level has the same amount of work - which is very convenient, as we can now just take that quantity and multiply it by the number of levels. So in total, when we solve out the recurrence, we should obtain that $W(n) = (\sum_{i=1}^{\log_2(n)} c_1\frac{n}{2}) + c_2n$, since the $c_2n$ term is separately obtained from the base level, due to the $n$ leaves that each have $c_2$ work.
 
-The term $\sum\_{i=1}^{\log_2(n)} c_1\frac{n}{2}$ thus goes to $\frac{c_1}{2} n\log_2(n)$, so in total we obtain that $W(n) = \frac{c_1}{2} n\log_2(n) + c_2n$, which is in $O(n \log n)$. So we're done.
+The term $\sum_{i=1}^{\log_2(n)} c_1\frac{n}{2}$ thus goes to $\frac{c_1}{2} n\log_2(n)$, so in total we obtain that $W(n) = \frac{c_1}{2} n\log_2(n) + c_2n$, which is in $O(n \log n)$. So we're done.
 
 The tree method is really nothing more than just a visual way to view the recurrence - it is possible to achieve the same effect by just writing a summation. It is sometimes more intuitive to try and visualize, however, and for recurrences where the levels sum to the same amount, the tree method is very effective. However, not all recurrences exhibit such behavior, and it's hard to know _a priori_ whether a given recurrence is such a one. Nevertheless, it is a powerful method and sufficient for many purposes.
 

--- a/docs/concepts/basic/eeq.md
+++ b/docs/concepts/basic/eeq.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Extensional Equivalence
 
-_By Brandon Wu, June 2020_
+_By Brandon Wu, June 2020_. _Revised December 2022_
 
 Up to this point, we have been using terms such as "equal" and "equivalent" rather casually. Such a notion of equality seems to be rather intuitive, at first glance, not necessarily in need of more exposition. After all, it seems to be our intuition that if two things are equal, we will "know it when we see it". When working in the realm of mathematical expressions, we have some nice assumptions that lend credence to such a hypothesis - if we are evaluating the cosine of a number, we don't expect that the cosine function might wait forever before returning an answer to us. When working with SML code, this becomes a valid concern, and requires that we have a more particular definition of equivalence.
 
@@ -36,9 +36,9 @@ We will declare this definition of extensional equivalence for non-function expr
 >
 > 3.  Raise the same exception
 >
-> We will write `e == e'` to denote this.
+> We will write `e` $\cong$ `e'` to denote this.
 
-**NOTE:** `==` is not valid SML code.
+**NOTE:** When writing specification comments in code files, we often use `==` to denote extensional equivalence. `==` is not valid SML code, however.
 
 As such, clearly expressions such as `2 + 2` and `3 + 1` should be extensionally equivalent, since they reduce to the same value, that being `4`. It is important to note that reduction is a _stronger_ relation than extensional equivalence - if one expression reduces to another, then they must by definition be extensionally equivalent. However, extensional equivalence does not imply reduction. For instance, `4` does not reduce to `2 + 2`, since clearly `4` is already in its most simplified form. This corresponds to our intuition about traditional mathematical expressions, as we would expect that we could say that $-1$ and $\cos(\pi)$ are equal, since they have the same value.
 
@@ -58,7 +58,7 @@ For many cases, our intuition will suffice. It is clear to say that `2` is the s
 
 This definition will suffice for most types. For functions, however, we will have to take a different approach.
 
-> **[Extensional Equivalence (Functions)]** We say two expressions `e : t1 -> t2` and `e' : t1 -> t2` for some types `t1` and `t2` are extensionally equivalent if for all values `x : t1`, `e x`$\cong$`e' x`.
+> **[Extensional Equivalence (Functions)]** We say two expressions `e : t1 -> t2` and `e' : t1 -> t2` for some types `t1` and `t2` are extensionally equivalent if for all values `x : t1`, `e x` $\cong$ `e' x`.
 
 We see that this definition simply takes our previous definition and moves it one step up. There is an interesting aspect of this rule that depends on a concept that we have yet to learn, but we will cover that when we get there. Seen in this way, we can say that two function values that are not the same literal value may be extensionally equivalent, as their _extensional_ behavior (that is, their behavior when interacting with other objects) may be the same.
 
@@ -70,7 +70,7 @@ As discussed before, our definition of "equivalence" identifies functions with t
 
 In this section we will introduce a powerful idea called _referential transparency_, which follows as a direct consequence of our definition of extensional equivalence.
 
-> **[Referential Transparency]** Consider an expression `e` that contains the expression `e1` as a sub-expression. For any expression `e2`$\cong$`e1`, we can produce the expression `e'` as the same expression as `e`, but with each sub-expression `e1` replaced with `e2`, and we will have `e`$\cong$`e'`. In words, for an expression `e` that contains `e1`, we can swap out `e1` for an extensionally equivalent `e2` to obtain an expression extensionally equivalent to `e`.
+> **[Referential Transparency]** Consider an expression `e` that contains the expression `e1` as a sub-expression. For any expression `e2` $\cong$ `e1`, we can produce the expression `e'` as the same expression as `e`, but with each sub-expression `e1` replaced with `e2`, and we will have `e` $\cong$ `e'`. In words, for an expression `e` that contains `e1`, we can swap out `e1` for an extensionally equivalent `e2` to obtain an expression extensionally equivalent to `e`.
 
 **NOTE:** The notion of a "sub-expression" here is not very well defined - we will use our intuition here, similarly with what it means to be the "same expression". Gaining an intuition through examples will suffice.
 
@@ -95,27 +95,27 @@ fun [] @ L = L
 
 Now, suppose we want to show the following theorem:
 
-$$(x::xs) @ (rev A) \cong x::(xs @ (rev A))$$
+$$\texttt{(x::xs) @ (rev A)} \cong \texttt{x::(xs @ (rev A))}$$
 
 where `x : int`, `xs : int list`, and `A : int list` are all values. First, make sure this "feels right" -- the left side of our theorem matches the second clause of `@` with `rev A` bound to `L`.
 
 However, notice that `rev A` is not a value. Since SML is eager, we cannot step into the function `@` until we evaluate the expression `rev A`. In other words,
 
-$$(x::xs) @ (rev A) \not\Longrightarrow x::(xs @ (rev A))$$
+$$\texttt{(x::xs) @ (rev A)} \not\Longrightarrow \texttt{x::(xs @ (rev A))}$$
 
 So, we're stuck! D:
 
 ... or are we?
 
-Let's assume that `rev A` is valuable, i.e. it evaluates to a value, and let's give that value a name-- say, `v : int list`: \\[ `rev A` \Longrightarrow `v` \\] With this value in hand, we can do what we wanted to do!
+Let's assume that `rev A` is valuable, i.e. it evaluates to a value, and let's give that value a name-- say, `v : int list`: \[ `rev A` $\Longrightarrow$ `v` \] With this value in hand, we can do what we wanted to do!
 
-$$(x::xs) @ (rev A) \Longrightarrow (x::xs) @ v \Longrightarrow x::(xs @ v)$$
+$$\texttt{(x::xs) @ (rev A)} \Longrightarrow \texttt{(x::xs) @ v} \Longrightarrow \texttt{x::(xs @ v)}$$
 
 Notice that this complies with SML's eager evaluation, since we are fully evaluating the parameters of `@` before stepping into the function.
 
 And here's the kicker: we can also use `v` to evaluate the right hand side of our theorem!
 
-$$x::(xs @ (rev A)) \Longrightarrow x::(xs @ v)$$
+$$\texttt{x::(xs @ (rev A))} \Longrightarrow \texttt{x::(xs @ v)}$$
 
 Again, this complies with SML's eager evaluation-- in this case, we never even step into the definition of `@`. But, we've actually proven our theorem! We showed that the LHS and the RHS both evaluate to the same expression, so by rule 1 of the definition of $\cong$, the LHS and RHS must be extensionally equivalent. We are done!
 

--- a/docs/concepts/hof/common.md
+++ b/docs/concepts/hof/common.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Common HOFs and Partial Evaluation
 
-_By Brandon Wu, June 2020. Revised March 2022_
+_By Brandon Wu, June 2020. Revised December 2022_
 
 In this section, we will explore a number of common higher-order functions that we will make use of. These higher-order functions embody _design patterns_ that are common in programming, and represent a _generalized notion_ of a large space of potential functions that can be made to solve a myriad of problems. This section focuses on understanding the importance that higher-order functions offer us through increasing _abstraction_, as well as _modularity_ in the structure of our code.
 
@@ -82,7 +82,7 @@ fun foldr g z [] = z
   | foldr g z (x::xs) = g(x, foldr g z xs)
 ```
 
-More specifically, `foldl` and `foldr` both describe two ways of combining the elements in a list, given a function `g`. The role of `z` is that of a "base case" in our accumulated value, so that we have an initial point to start from when using the function `g`. The result of `foldl g z [x_1, ..., x_n]` is to evaluate to `f(x_n, ..., f(x_2, f(x_1, z))...)`, and the result of `foldr g z [x_1, ..., x_n]` is to evaluate to `f(x_1, ..., f(x_n-1, f(x_n, z))...)`. We are thus choosing whether we want to fold from the _left_ of the list or the _right_.
+More specifically, `foldl` and `foldr` both describe two ways of combining the elements in a list, given a function `g`. The role of `z` is that of a "base case" in our accumulated value, so that we have an initial point to start from when using the function `g`. The result of `foldl g z [x_1, ..., x_n]` is to evaluate to `g(x_n, ..., g(x_2, g(x_1, z))...)`, and the result of `foldr g z [x_1, ..., x_n]` is to evaluate to `g(x_1, ..., g(x_n-1, g(x_n, z))...)`. We are thus choosing whether we want to fold from the _left_ of the list or the _right_.
 
 **NOTE:** One way to remember which way that that each respective `fold` goes is to identify the corresponding side (left or right) as being the side of the most _deeply nested_ element in the functions. As such, since `x_1` is the most leftmost element, `foldl` has `f(x_1, z)` as its innermost component, whereas since `x_n` is the most rightmost element, `foldr` has `f(x_n, z)`.
 


### PR DESCRIPTION
- Work/Span: Fixed a bunch of LaTeX typos
- Extensional Equivalence: Fixed a minor LaTeX misrendering, changed some LaTeX formatting to make it look nicer, made sure use of `==` vs \cong was consistent in article (and clarified that `==` is only used in code comments)
- HOFs: Fixed typo in `foldr`/`foldr` explanation (used an undefined function `f` instead of `g`)