### PR TITLE
Add a Beyond Section

### DIFF
--- a/docs/concepts/beyond/README.md
+++ b/docs/concepts/beyond/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 11
+---
+
+# Beyond
+
+This section contains a variety of information that we decided wasn't essential
+for basic knowledge, but may be useful for further use of SML. There isn't
+necessarily a logical ordering of these pages, so no need to read them in order.

--- a/docs/concepts/beyond/more-syntax.md
+++ b/docs/concepts/beyond/more-syntax.md
@@ -1,0 +1,108 @@
+---
+sidebar_position: 3
+---
+
+# Additional Modules Syntax
+
+_By Thea Brick, January 2023_
+
+Modules in general are fairly complex. Due to this, we mostly focused on a
+subset of the available syntax. That is not to these things are not useful
+though.
+
+## The `open`/`include` Keyword for Modules
+
+These are very simple, but often useful declarations. The `open` declaration
+takes a structure and places everything defined within it into scope. For
+instance, if you were to write `open Int`, then you could just call `toString`
+to get the `Int.toString` function instead.
+
+The `include` keyword is essentially identical, but instead operates on the
+signature/specification level. Writing `include SIGNATURE` essentially inserts
+all the specification defined in the signature into wherever the `include` is
+placed.
+
+## The `where` Keyword for Modules
+
+The `where` syntax allows the sharing of abstract type information for a
+structure which otherwise uses opaque ascription. This is useful because we
+generally want to always use opaque ascription, as not letting outside programs
+mess with internal representations is important, yet there are some instances
+where knowledge of the representation is essential, but it doesn't make sense
+to make the type concrete.
+
+There `where` keyword appears after the signature which it is being applied to.
+Here is an example of what the `where` keyword does.
+
+
+```sml
+signature EXAMPLE =
+sig
+  type t (* abstract *)
+  type u (* abstract *)
+  type v (* abstract *)
+end
+
+signature EXAMPLE2 = EXAMPLE where type t = int
+```
+
+The type `t` is no longer abstract in `EXAMPLE2` rather it is defined to be
+`int`. Likewise this can be done for multiple types, either through chaining
+`where`s or through the `and` keyword.
+
+```sml
+signature EXAMPLE3 = EXAMPLE where type t = int and type u = string
+```
+
+Only type `v` remains abstract.
+
+## The `sharing` Keyword for Modules
+
+Sharing (in SML) is stating that two types need to be the same. There are
+numerous complexities with this. In general, if one of the types that is
+being shared is not abstract, then it cannot be shared.
+
+Here is a really basic example of type sharing:
+
+```sml
+signature EXAMPLE =
+sig
+  type t (* abstract *)
+  type u (* abstract *)
+  sharing type t = u
+end
+```
+
+This enforces that in any structure implementing `EXAMPLE`, the types `t` and
+`u` must be the same. This might seem a little silly, becaue we could easily
+write the following to do the same thing:
+
+```sml
+signature EXAMPLE2 =
+sig
+  type t (* abstract *)
+  type u = t
+end
+```
+
+This does do the same thing. And in fact, it is prefered to the first example,
+so sharing should be avoided if possible. Yet, there are some scenarios where
+sharing is useful. For instance, enforcing two different structures use the
+same type:
+
+```sml
+signature EXAMPLE3 =
+sig
+  type t (* abstract *)
+end
+
+signature EXAMPLE4 =
+sig
+  structure S1 : EXAMPLE3
+  structure S2 : EXAMPLE3
+  sharing type S1.t = S2.t
+end
+```
+
+In this case, the two structures `S1` and `S2` must have the same type for `t`,
+and without the `sharing` specification this could not be enforced.

--- a/docs/concepts/beyond/multi-files.md
+++ b/docs/concepts/beyond/multi-files.md
@@ -1,0 +1,142 @@
+---
+sidebar_position: 2
+---
+
+# Multi-File Projects
+
+_By Thea Brick, January 2023_
+
+When working with larger projects, we need a way to effectively load various SML
+files, sharing common libraries functions, etc. SML does not define a specific
+method to do this, so multiple standards have arose. The SML/NJ compiler uses CM
+(compilation manager) files and MLton uses MLB (ML basis) files. Both systems
+are used and have unique pros and cons, so we will discuss them both. That being
+said, each has their own associated documentation, so we will not go completely
+in depth.
+
+There is also a utility called [Molasses](https://github.com/T-Brick/molasses)
+which can compile (most) SML programs using MLB files into SML programs using CM
+files, allowing MLton programs to be ran in the SML/NJ REPL.
+
+
+## MLB Files
+
+See the official documentation [here](http://mlton.org/MLBasis).
+
+MLB files allow for the sharing of expression-level declarations, infix
+declarations, and structure-level declarations between SML files. It is a
+sequence of files (SML and MLB) which are loaded sequentially.
+
+MLB files referenced are all merged together to form a basis, and then the SML
+files can build upon this basis to add additional bindings. For instance,
+considering the following example file.
+
+```sml
+lib1.mlb
+lib2.mlb
+file1.sml
+file2.sml
+```
+
+First `lib1.mlb` is loaded and is added to a basis. Then, `lib2.mlb` is loaded
+and is also added to the basis. Importantly, declarations added by `lib1.mlb`
+cannot be used in `lib2.mlb` (they are considered separate libraries). The
+declarations in `lib2.mlb` potentially shadow the declarations in `lib1.mlb`.
+
+Then, `file1.sml` is loaded using and expanding the basis. This means that
+`file1.sml` can use all the declarations in the combined `lib1.mlb` and
+`lib2.mlb`. Finally, `file2.sml` can use all the declarations defined in all the
+priorly discussed files.
+
+If we want to limit what signature, structures, and functors we can see, we do
+so with a `local` expression (different from the SML version). For instance,
+this example limits the imports from `mlb` files:
+
+```sml
+local
+  lib1.mlb
+  lib2.mlb
+in
+  structure A
+  structure C = B (* example of renaming structure B *)
+  functor F
+end
+file1.sml (* only structure A, C, and functor F are available *)
+```
+
+Conversely, we can limit exports of our MLB file by doing the same thing, but
+for the SML files:
+
+```sml
+local
+  file1.sml
+  file2.sml
+in
+  structure C = B (* example of renaming structure B *)
+  functor F
+end (* only structure C and F may be used in importing files *)
+```
+
+### MLB Path Variables
+
+These are simply variables defined at compile time that allow us to adjust how
+and what files are loaded. They can also be used so that the exact path of a
+file doesn't need to be known when writing the MLB file.
+
+These are denoted as `$(PATH_VARIABLE)` in the MLB file. The most common path
+variable you may see is `$(SML_LIB)`, which is by default the path for the
+SML implementation. So you may see something along the lines of:
+
+```sml
+$(SML_LIB)/basis/basis.mlb
+```
+
+Which loads the Standard Basis Library. More libraries can be found
+[here](http://mlton.org/MLBasisAvailableLibraries).
+
+
+## CM Files
+
+See the official documentation [here](https://www.smlnj.org/doc/CM/new.pdf).
+
+CM files allow for _only_ the export of structure-level declarations between
+files. It is defined by two different type of files. A library file and a
+library component file (called a group). Importantly, a group may only be used
+by one library which references it. It may be referenced by as many other
+groups, so long as they all exist within the same library.
+
+In general, the cabailities of CM files are very complex and there are tons of
+interesting features which can be used. In other words, this is very brief
+overview of CM files. So, read the documentation if you want to learn more.
+
+A CM library file is structured as follows
+
+```sml
+Library
+  signature A
+  structure B
+  functor F
+is
+  lib1.cm
+  lib2.cm
+  file1.sml
+  file2.sml
+```
+
+Between the `Library` and `is` contain the declarations which are being exported
+and may be used outside of the library. There must be at least one such
+declaration. Below the `is` is a list of files used in the library. These files
+do not need to be ordered.
+
+A group is similar to a `library` but the `Library` keyword is replaced by
+`Group`, and the export list can be left blank and will be infered from the
+exports in the files.
+
+### Anchors
+
+These are variables which can appear in CM files. They are often used to give a
+shorthand of common paths. They are denoted as `$ANCHOR_NAME` and they must
+appear at the start of a file path.
+
+You may see `$/basis.cm` which implements the Standard Basis Library. Likewise,
+`$/smlnj-lib.cm` implement a variety of extensions provided by SML/NJ.

--- a/docs/concepts/beyond/records.md
+++ b/docs/concepts/beyond/records.md
@@ -1,0 +1,130 @@
+---
+sidebar_position: 1
+---
+
+# Records
+
+_By Thea Brick, January 2023_
+
+In the prior chapters we've used tuples as a method to carry around multiple,
+distinct pieces of information. Using tuples for this is perfectly reasonable
+for simple programs or places where we are only passing around a couple of
+things, but often we need to handle much more than a couple things. We may also
+want to convey information about what is being passed in (for readability).
+
+
+## The Type
+
+To support this, SML provides the record type, which can be thought of as a
+labeled tuple. This means we can have a record of any length[^1] but each field
+has an additional label that we can use for accessing it (rather than just
+using the position). Here's an example of creating and using one:
+
+```sml
+type version = { id : int, name : string, date : string }
+```
+
+Any value of the `version` type must have the fields `id : int`,
+`name : string`, and `date : string` importantly with no additional fields. We
+may already see why this may be desired. If we had just used a tuple (e.g.
+`int * string * string`) then there is no distinction (without documentation)
+between the `name` and the `date`.
+
+You don't need to use a type declaration to define a record though. You can use
+it anywhere, just like a tuple.
+
+```sml
+datatype 'a tree = Empty
+                 | Node of { left : 'a tree, value : 'a, right : 'a tree }
+
+val example : { tree : int tree, size : int } = (* omitted *)
+```
+
+
+## The Expression
+
+To create values of these record types, we follow a very similar syntax:
+
+```sml
+val version : version = {id=150, name="SMLhelp", date="Oct 23"}
+```
+
+Every field must be defined in order for the type to match (with no additional
+ones), but the ordering does not matter.
+
+Now that we have these records how do we use them. There are two methods to go
+about this, accessors and pattern-matching. An accessor is simply the `#` with
+the name of the field desired immediately after[^2]. For instance:
+
+```sml
+val getName : version -> string = fn version => #name version
+```
+
+Alternatively we can pattern-match instead. There are numerous different ways
+to pattern match, which you can use for various situations. For instance, the
+most basic method is as follows:
+
+```sml
+val getName : version -> string =
+  fn {name = n, id = i, date = d} => n
+```
+
+We don't care about the `id` and `date` fields for this function, so we can use
+`...` to omit those any field we don't care about from our record pattern:
+```sml
+val getName : version -> string = fn {name = n, ...} => n
+```
+
+Finally, `name` is the name of our field, but it would also be fine as the name
+for our variable. So we can not include an `=`s and SML will bind the field to a
+variable of the same name:
+```sml
+val getName : version -> string = fn {name, ...} => name
+```
+
+
+## The Pitfalls
+
+From above, we have the following declaration:
+
+```sml
+val getName : version -> string = fn version => #name version
+```
+
+You may see this and think "hmmm... I can simplify this a bit," And write
+something along the lines of:
+
+```sml
+val getName = fn v => #name v
+val getName = fn {name, ...} => name (* alternatively *)
+```
+
+If you try and compile this, you'll get a type error, specifically an
+"unresolved flex record," SML is able to determine what the `getName` function
+should take in a record with at least the field `name`, but it can't infer
+anything else. It could reasonably be `{ name : 'a }` or
+`{ name : 'a, id : 'b}`, or
+`{ name : 'a, id : 'b, ijoergnq : 'c list list list}`, or any other
+possibility. The `getName` function can only be one type, so this isn't allowed.
+
+There are two common workarounds for this. This first is just to annotate your
+types! If we specifically say `getName` must take in a value of type `version`,
+then there is no abiguity, so no error. The other workaround involves wrapping
+a record in a constructor, which enforces the type of the record. To implement
+this we might change our code to the following:
+
+```sml
+datatype version = Version of { id : int, name : string, date : string }
+
+val getName = fn Version v => #name v
+```
+
+Thus, we know what fields `v` has, since the type can be infered by the
+constructor it is associated with.
+
+[^1]: If you were curious, the empty record `{}` is equivalent to `()`, thus
+has type `unit`.
+
+[^2]: The same can be done for tuples, where `#1` accesses the first value in
+the tuple, `#2` for the second, etc.
+

--- a/docs/concepts/beyond/val-restrict.md
+++ b/docs/concepts/beyond/val-restrict.md
@@ -1,0 +1,65 @@
+---
+sidebar_position: 4
+---
+
+# Oh No! The Value Restriction
+
+_By Thea Brick, January 2023_
+
+First lets consider the following declaration:
+
+```sml
+val example = ref NONE
+```
+
+We can ask ourselves, what is the type of `example`. Surely it should be
+`'a option ref`. Yet this can yield some problems:
+
+```sml
+val () = example := SOME 5
+val () = example := SOME "string"
+```
+
+The first line requires that `example` must be `int option ref`, but then the
+second line requires that `example` be a `string option ref`. This doesn't work,
+`example` cannot be both of these types. So something went wrong when we decided
+the original type of `example`.
+
+To solve this issue, we can place restrictions on what is allowed to have a
+polymorphic type. Specifically, an declaration can only have a polymorphic type
+variable if the expression on the right hand side of the declaration is a
+"non-expansive expression," Essentially, what this means is that the expression
+on the right hand side must be a value and cannot alter the state (or memory) of
+the program.
+
+When something is value restricted, this means that we replace it with a unique
+dummy type, so the following example above doesn't work because the definition
+of `example` gets value restricted (since `ref NONE` is expansive, it modifies
+state). So when we try to assign `example` to `SOME 5` or `SOME "string"` it
+doesn't work because the dummy type is not a `int` nor a `string`.
+
+Importantly, this still allows us to use most forms of polymorphism:
+
+```sml
+val none : 'a option = NONE
+val id : 'a -> 'a = fn x => x
+val magic : 'a -> 'b = fn _ => raise Fail "Magic"
+```
+
+Unfortunately, the rules for the value restriction is pretty blunt, thus some
+completely fine expressions get value restricted:
+
+```sml
+(* should be `'a -> 'a` but isn't since `id id` isn't a value *)
+val id2 = id id
+```
+
+Generally, this can be avoided in many cases. If you are working with a function
+then you can usually wrap it in another function:
+
+```sml
+val id2 = fn x => id id x
+```
+
+Although if you are working with `ref`s or other imperative features then be
+careful, since this could potentially modify behaviour.


### PR DESCRIPTION
This adds a new section after the imperative page about a few topics that we don't quite address in 150, but are fairly accessible and useful for anyone trying to use SML. Namely, it adds a page about Records, a page for some of the modules syntax we don't really talk about, CM and MLB files, and the value restriction.
