### PR TITLE
fix compose in common HOFs page

### DIFF
--- a/docs/concepts/hof/common.md
+++ b/docs/concepts/hof/common.md
@@ -102,7 +102,7 @@ We could, of course, write the lambda expression `fn x => f1 (f2 (f3 (f4 (f5 x))
 
 ```sml
 infix o
-(* o : ('b -> 'c) -> ('a -> 'b) -> ('a -> 'c) *)
+(* o : ('b -> 'c) * ('a -> 'b) -> ('a -> 'c) *)
 fun f o g = fn x => f (g x)
 ```
 


### PR DESCRIPTION
Currently, the type of compose is `(* o : ('b -> 'c) -> ('a -> 'b) -> ('a -> 'c) *)`. However since compose is an infix operator it should take in a tuple rather than be curried. I have fixed this. 